### PR TITLE
selinux: Fix labels for BT/wlan persist datafiles

### DIFF
--- a/sepolicy/file_contexts
+++ b/sepolicy/file_contexts
@@ -10,3 +10,6 @@
 /sys/devices/virtual/graphics/fb0/sre               u:object_r:display_sysfs:s0
 
 /sys/devices/virtual/timed_output/vibrator/vtg_level   u:object_r:vibeamp_sysfs:s0
+
+/persist/.genmac                                u:object_r:wifi_data_file:s0
+/persist/.bt_nv.bin                             u:object_r:bluetooth_data_file:s0


### PR DESCRIPTION
Change-Id: Iebb97852fe32ee23b600419e8382cbb02dc4a34b