### PR TITLE
init: Move qseecomd out of late_start

### DIFF
--- a/rootdir/etc/init.qcom-common.rc
+++ b/rootdir/etc/init.qcom-common.rc
@@ -518,7 +518,7 @@ service loc_launcher /system/bin/loc_launcher
     group gps qcom_oncrpc inet net_raw qcom_diag net_admin wifi
 
 service qseecomd /system/bin/qseecomd
-    class late_start
+    class core
     user root
     group root
 


### PR DESCRIPTION
Let's keep the crypto daemon out of the classes that get shut down
while encrypting... :-)

Change-Id: I8e00cf9b49e319f25b6603ad049c629f125e622e