### PR TITLE
media_profiles: Match the timelapselow profiles with the low ones

### DIFF
--- a/configs/media_profiles.xml
+++ b/configs/media_profiles.xml
@@ -252,16 +252,16 @@
 
     <EncoderProfile quality="timelapselow" fileFormat="mp4" duration="30">
       <Video codec="h264"
-             bitRate="192000"
-             width="176"
-             height="144"
+             bitRate="512000"
+             width="320"
+             height="240"
              frameRate="30" />
 
       <!-- audio setting is ignored -->
-      <Audio codec="amrnb"
-             bitRate="12200"
-             sampleRate="8000"
-             channels="1" />
+      <Audio codec="aac"
+             bitRate="156000"
+             sampleRate="48000"
+             channels="2" />
     </EncoderProfile>
 
     <EncoderProfile quality="timelapsehigh" fileFormat="mp4" duration="30">
@@ -588,16 +588,16 @@
 
     <EncoderProfile quality="timelapselow" fileFormat="mp4" duration="30">
       <Video codec="h264"
-             bitRate="192000"
-             width="176"
-             height="144"
+             bitRate="512000"
+             width="320"
+             height="240"
              frameRate="30" />
 
       <!-- audio setting is ignored -->
-      <Audio codec="amrnb"
-             bitRate="12200"
-             sampleRate="8000"
-             channels="1" />
+      <Audio codec="aac"
+             bitRate="156000"
+             sampleRate="48000"
+             channels="2" />
     </EncoderProfile>
 
     <EncoderProfile quality="timelapsehigh" fileFormat="mp4" duration="30">


### PR DESCRIPTION
A previous change increased the size of the low profiles but did not
update the timelapse ones to match them. This causes mediarecorer
timelapse sessions to fail if they pick the timelapse low profile.

Change-Id: I74e53f152e5c0a04b88b11692bda927c66bd5b86